### PR TITLE
fix(StreamContentEntryMixin): join default "," destroys content

### DIFF
--- a/src/stream-content-entry-mixin.mjs
+++ b/src/stream-content-entry-mixin.mjs
@@ -12,7 +12,7 @@ export function StreamContentEntryMixin(superclass) {
         chunks.push(chunk);
       }
 
-      return chunks.join();
+      return chunks.join("");
     }
 
     async setString(value, options = defaultStringOptions) {


### PR DESCRIPTION
Hello Markus, we have a problem using this module, the file which will read is json and has over 2000 lines, join connect the chunks with "," afterwards we try to make JSON.parse and get error that the JSON is not readable